### PR TITLE
add declare to top level declarations in .d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ interface ReadabilityConfig {
 	skipGunningFog?: boolean
 }
 
-function readabilityScores(
+declare function readabilityScores(
 	value: string,
 	config?: ReadabilityConfig
 ): {


### PR DESCRIPTION
Fixes `node_modules/readability-scores/index.d.ts(19,1): error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.`